### PR TITLE
Support use on 32-bit architectures

### DIFF
--- a/lock_rw.go
+++ b/lock_rw.go
@@ -9,11 +9,11 @@ type RWMutex struct {
 	lock sync.RWMutex
 
 	// internal trace fields
-	threshold        uint64 // 0 when disabled, else threshold in nanoseconds
-	beginAwaitLock   uint64 // start time in unix nanoseconds from start waiting for lock
-	beginAwaitUnlock uint64 // start time in unix nanoseconds from start waiting for unlock
-	lockObtained     uint64 // once we've entered the lock in unix nanoseconds
-	id               []byte // if set this will be printed as string
+	threshold        atomic.Uint64 // 0 when disabled, else threshold in nanoseconds
+	beginAwaitLock   atomic.Uint64 // start time in unix nanoseconds from start waiting for lock
+	beginAwaitUnlock atomic.Uint64 // start time in unix nanoseconds from start waiting for unlock
+	lockObtained     atomic.Uint64 // once we've entered the lock in unix nanoseconds
+	id               []byte        // if set this will be printed as string
 }
 
 func (m *RWMutex) Lock() {
@@ -73,22 +73,22 @@ func (m *RWMutex) RUnlock() {
 }
 
 func (m *RWMutex) isTracing() Threshold {
-	tracingThreshold := atomic.LoadUint64(&m.threshold)
+	tracingThreshold := m.threshold.Load()
 	if tracingThreshold == 0 {
 		// always on?
-		tracingThreshold = atomic.LoadUint64(&defaultThreshold)
+		tracingThreshold = defaultThreshold.Load()
 	}
 	return Threshold(tracingThreshold)
 }
 
 func (m *RWMutex) traceBeginAwaitLock() {
-	atomic.StoreUint64(&m.beginAwaitLock, now())
+	m.beginAwaitLock.Store(now())
 }
 
 func (m *RWMutex) traceEndAwaitLock(threshold Threshold) {
 	ts := now() // first obtain the current time
-	start := atomic.LoadUint64(&m.beginAwaitLock)
-	atomic.StoreUint64(&m.lockObtained, uint64(ts))
+	start := m.beginAwaitLock.Load()
+	m.lockObtained.Store(uint64(ts))
 	var took uint64
 	if start < ts {
 		// check for no overflow
@@ -100,14 +100,14 @@ func (m *RWMutex) traceEndAwaitLock(threshold Threshold) {
 }
 
 func (m *RWMutex) traceBeginAwaitUnlock() {
-	atomic.StoreUint64(&m.beginAwaitUnlock, now())
+	m.beginAwaitUnlock.Store(now())
 }
 
 func (m *RWMutex) traceEndAwaitUnlock(threshold Threshold) {
 	ts := now() // first obtain the current time
 
 	// lock obtained time (critical section)
-	lockObtained := atomic.LoadUint64(&m.lockObtained)
+	lockObtained := m.lockObtained.Load()
 	var took uint64
 	if lockObtained < ts {
 		// check for no overflow

--- a/lock_rw_test.go
+++ b/lock_rw_test.go
@@ -1,34 +1,33 @@
-package muxtracer_test
+package muxtracer
 
 import (
-	sync "github.com/lukemarsden/golang-mutex-tracer"
-	nativeSync "sync"
+	"sync"
 	"testing"
 	"time"
 )
 
 func TestRWNew(t *testing.T) {
-	l := sync.RWMutex{}
+	l := RWMutex{}
 	l.Lock()
 	l.Unlock()
 }
 
 func TestRWNewEnabled(t *testing.T) {
-	l := sync.RWMutex{}
+	l := RWMutex{}
 	l.EnableTracer()
 	l.Lock()
 	l.Unlock()
 }
 
 func TestRWNewDisabled(t *testing.T) {
-	l := sync.RWMutex{}
+	l := RWMutex{}
 	l.DisableTracer()
 	l.Lock()
 	l.Unlock()
 }
 
 func TestRWNewEnabledDisabledHalfWay(t *testing.T) {
-	l := sync.RWMutex{}
+	l := RWMutex{}
 	l.EnableTracer()
 	l.Lock()
 	l.DisableTracer()
@@ -36,7 +35,7 @@ func TestRWNewEnabledDisabledHalfWay(t *testing.T) {
 }
 
 func TestRWNewEnabledDisabledEnd(t *testing.T) {
-	l := sync.RWMutex{}
+	l := RWMutex{}
 	l.EnableTracer()
 	l.Lock()
 	l.Unlock()
@@ -44,10 +43,10 @@ func TestRWNewEnabledDisabledEnd(t *testing.T) {
 }
 
 func TestRWNewEnableGlobal(t *testing.T) {
-	l := sync.RWMutex{}
+	l := RWMutex{}
 
 	// enable globally
-	sync.SetGlobalOpts(sync.Opts{
+	SetGlobalOpts(Opts{
 		Threshold: 100 * time.Millisecond,
 		Enabled:   true,
 	})
@@ -57,11 +56,11 @@ func TestRWNewEnableGlobal(t *testing.T) {
 	l.Unlock()
 
 	// reset again
-	sync.ResetDefaults()
+	ResetDefaults()
 }
 
 func TestRWNewEnabledHalfWay(t *testing.T) {
-	l := sync.RWMutex{}
+	l := RWMutex{}
 	l.Lock()
 	l.EnableTracer()
 	l.Unlock()
@@ -69,7 +68,7 @@ func TestRWNewEnabledHalfWay(t *testing.T) {
 }
 
 func TestRWNewEnabledShortDelay(t *testing.T) {
-	l := sync.RWMutex{}
+	l := RWMutex{}
 	l.EnableTracer()
 	l.Lock()
 	time.Sleep(1 * time.Millisecond)
@@ -78,7 +77,7 @@ func TestRWNewEnabledShortDelay(t *testing.T) {
 }
 
 func TestRWNewEnabledLongDelay(t *testing.T) {
-	l := sync.RWMutex{}
+	l := RWMutex{}
 	l.EnableTracer()
 	l.Lock()
 	time.Sleep(150 * time.Millisecond)
@@ -87,8 +86,8 @@ func TestRWNewEnabledLongDelay(t *testing.T) {
 }
 
 func TestRWNewEnabledAwaitLock(t *testing.T) {
-	l := sync.RWMutex{}
-	l.EnableTracerWithOpts(sync.Opts{
+	l := RWMutex{}
+	l.EnableTracerWithOpts(Opts{
 		Threshold: 10 * time.Millisecond,
 	})
 	go func() {
@@ -104,8 +103,8 @@ func TestRWNewEnabledAwaitLock(t *testing.T) {
 }
 
 func TestRWNewEnabledId(t *testing.T) {
-	l := sync.Mutex{}
-	l.EnableTracerWithOpts(sync.Opts{
+	l := Mutex{}
+	l.EnableTracerWithOpts(Opts{
 		Threshold: 10 * time.Millisecond,
 		Id:        "testRwLock",
 	})
@@ -116,7 +115,7 @@ func TestRWNewEnabledId(t *testing.T) {
 }
 
 func BenchmarkRWNativeLock(b *testing.B) {
-	l := sync.RWMutex{}
+	l := RWMutex{}
 	for n := 0; n < b.N; n++ {
 		l.Lock()
 		l.Unlock()
@@ -124,7 +123,7 @@ func BenchmarkRWNativeLock(b *testing.B) {
 }
 
 func BenchmarkRWTracerLockDisabled(b *testing.B) {
-	l := sync.RWMutex{}
+	l := RWMutex{}
 	for n := 0; n < b.N; n++ {
 		l.Lock()
 		l.Unlock()
@@ -132,7 +131,7 @@ func BenchmarkRWTracerLockDisabled(b *testing.B) {
 }
 
 func BenchmarkRWTracerLockEnabled(b *testing.B) {
-	l := sync.RWMutex{}
+	l := RWMutex{}
 	l.EnableTracer()
 	for n := 0; n < b.N; n++ {
 		l.Lock()
@@ -141,8 +140,8 @@ func BenchmarkRWTracerLockEnabled(b *testing.B) {
 }
 
 func BenchmarkRWNativeLockWithConcurrency(b *testing.B) {
-	l := sync.RWMutex{}
-	wg := nativeSync.WaitGroup{}
+	l := RWMutex{}
+	wg := sync.WaitGroup{}
 	wg.Add(numRoutines)
 	for i := 0; i < numRoutines; i++ {
 		go func() {
@@ -157,8 +156,8 @@ func BenchmarkRWNativeLockWithConcurrency(b *testing.B) {
 }
 
 func BenchmarkRWTracerLockDisabledWithConcurrency(b *testing.B) {
-	l := sync.RWMutex{}
-	wg := nativeSync.WaitGroup{}
+	l := RWMutex{}
+	wg := sync.WaitGroup{}
 	wg.Add(numRoutines)
 	for i := 0; i < numRoutines; i++ {
 		go func() {
@@ -173,9 +172,9 @@ func BenchmarkRWTracerLockDisabledWithConcurrency(b *testing.B) {
 }
 
 func BenchmarkRWTracerLockEnabledWithConcurrency(b *testing.B) {
-	l := sync.RWMutex{}
+	l := RWMutex{}
 	l.EnableTracer()
-	wg := nativeSync.WaitGroup{}
+	wg := sync.WaitGroup{}
 	wg.Add(numRoutines)
 	for i := 0; i < numRoutines; i++ {
 		go func() {

--- a/lock_test.go
+++ b/lock_test.go
@@ -1,8 +1,7 @@
-package muxtracer_test
+package muxtracer
 
 import (
-	sync "github.com/lukemarsden/golang-mutex-tracer"
-	nativeSync "sync"
+	"sync"
 	"testing"
 	"time"
 )
@@ -10,27 +9,27 @@ import (
 const numRoutines = 16
 
 func TestNew(t *testing.T) {
-	l := sync.Mutex{}
+	l := Mutex{}
 	l.Lock()
 	l.Unlock()
 }
 
 func TestNewEnabled(t *testing.T) {
-	l := sync.Mutex{}
+	l := Mutex{}
 	l.EnableTracer()
 	l.Lock()
 	l.Unlock()
 }
 
 func TestNewDisabled(t *testing.T) {
-	l := sync.Mutex{}
+	l := Mutex{}
 	l.DisableTracer()
 	l.Lock()
 	l.Unlock()
 }
 
 func TestNewEnabledDisabledHalfWay(t *testing.T) {
-	l := sync.Mutex{}
+	l := Mutex{}
 	l.EnableTracer()
 	l.Lock()
 	l.DisableTracer()
@@ -38,7 +37,7 @@ func TestNewEnabledDisabledHalfWay(t *testing.T) {
 }
 
 func TestNewEnabledDisabledEnd(t *testing.T) {
-	l := sync.Mutex{}
+	l := Mutex{}
 	l.EnableTracer()
 	l.Lock()
 	l.Unlock()
@@ -46,10 +45,10 @@ func TestNewEnabledDisabledEnd(t *testing.T) {
 }
 
 func TestNewEnableGlobal(t *testing.T) {
-	l := sync.Mutex{}
+	l := Mutex{}
 
 	// enable globally
-	sync.SetGlobalOpts(sync.Opts{
+	SetGlobalOpts(Opts{
 		Threshold: 100 * time.Millisecond,
 		Enabled:   true,
 	})
@@ -59,11 +58,11 @@ func TestNewEnableGlobal(t *testing.T) {
 	l.Unlock()
 
 	// reset again
-	sync.ResetDefaults()
+	ResetDefaults()
 }
 
 func TestNewEnabledHalfWay(t *testing.T) {
-	l := sync.Mutex{}
+	l := Mutex{}
 	l.Lock()
 	l.EnableTracer()
 	l.Unlock()
@@ -71,7 +70,7 @@ func TestNewEnabledHalfWay(t *testing.T) {
 }
 
 func TestNewEnabledShortDelay(t *testing.T) {
-	l := sync.Mutex{}
+	l := Mutex{}
 	l.EnableTracer()
 	l.Lock()
 	time.Sleep(1 * time.Millisecond)
@@ -80,7 +79,7 @@ func TestNewEnabledShortDelay(t *testing.T) {
 }
 
 func TestNewEnabledLongDelay(t *testing.T) {
-	l := sync.Mutex{}
+	l := Mutex{}
 	l.EnableTracer()
 	l.Lock()
 	time.Sleep(150 * time.Millisecond)
@@ -89,8 +88,8 @@ func TestNewEnabledLongDelay(t *testing.T) {
 }
 
 func TestNewEnabledAwaitLock(t *testing.T) {
-	l := sync.Mutex{}
-	l.EnableTracerWithOpts(sync.Opts{
+	l := Mutex{}
+	l.EnableTracerWithOpts(Opts{
 		Threshold: 10 * time.Millisecond,
 	})
 	go func() {
@@ -106,8 +105,8 @@ func TestNewEnabledAwaitLock(t *testing.T) {
 }
 
 func TestNewEnabledId(t *testing.T) {
-	l := sync.Mutex{}
-	l.EnableTracerWithOpts(sync.Opts{
+	l := Mutex{}
+	l.EnableTracerWithOpts(Opts{
 		Threshold: 10 * time.Millisecond,
 		Id:        "testLock",
 	})
@@ -118,7 +117,7 @@ func TestNewEnabledId(t *testing.T) {
 }
 
 func BenchmarkNativeLock(b *testing.B) {
-	l := nativeSync.Mutex{}
+	l := sync.Mutex{}
 	for n := 0; n < b.N; n++ {
 		l.Lock()
 		l.Unlock()
@@ -126,7 +125,7 @@ func BenchmarkNativeLock(b *testing.B) {
 }
 
 func BenchmarkTracerLockDisabled(b *testing.B) {
-	l := sync.Mutex{}
+	l := Mutex{}
 	for n := 0; n < b.N; n++ {
 		l.Lock()
 		l.Unlock()
@@ -134,7 +133,7 @@ func BenchmarkTracerLockDisabled(b *testing.B) {
 }
 
 func BenchmarkTracerLockEnabled(b *testing.B) {
-	l := sync.Mutex{}
+	l := Mutex{}
 	l.EnableTracer()
 	for n := 0; n < b.N; n++ {
 		l.Lock()
@@ -143,8 +142,8 @@ func BenchmarkTracerLockEnabled(b *testing.B) {
 }
 
 func BenchmarkNativeLockWithConcurrency(b *testing.B) {
-	l := nativeSync.Mutex{}
-	wg := nativeSync.WaitGroup{}
+	l := sync.Mutex{}
+	wg := sync.WaitGroup{}
 	wg.Add(numRoutines)
 	for i := 0; i < numRoutines; i++ {
 		go func() {
@@ -159,8 +158,8 @@ func BenchmarkNativeLockWithConcurrency(b *testing.B) {
 }
 
 func BenchmarkTracerLockDisabledWithConcurrency(b *testing.B) {
-	l := sync.Mutex{}
-	wg := nativeSync.WaitGroup{}
+	l := Mutex{}
+	wg := sync.WaitGroup{}
 	wg.Add(numRoutines)
 	for i := 0; i < numRoutines; i++ {
 		go func() {
@@ -175,9 +174,9 @@ func BenchmarkTracerLockDisabledWithConcurrency(b *testing.B) {
 }
 
 func BenchmarkTracerLockEnabledWithConcurrency(b *testing.B) {
-	l := sync.Mutex{}
+	l := Mutex{}
 	l.EnableTracer()
-	wg := nativeSync.WaitGroup{}
+	wg := sync.WaitGroup{}
 	wg.Add(numRoutines)
 	for i := 0; i < numRoutines; i++ {
 		go func() {

--- a/opts_default.go
+++ b/opts_default.go
@@ -8,7 +8,7 @@ import (
 
 var defaultGlobalOpts Opts
 var defaultGlobalOptsMux sync.RWMutex
-var defaultThreshold uint64
+var defaultThreshold atomic.Uint64
 
 func obtainGlobalOpts() Opts {
 	defaultGlobalOptsMux.RLock()
@@ -27,7 +27,7 @@ func SetGlobalOpts(o Opts) {
 	}
 	defaultGlobalOptsMux.Lock()
 	defaultGlobalOpts = o
-	atomic.StoreUint64(&defaultThreshold, uint64(o.Threshold))
+	defaultThreshold.Store(uint64(o.Threshold))
 	defaultGlobalOptsMux.Unlock()
 }
 

--- a/tracers.go
+++ b/tracers.go
@@ -2,7 +2,6 @@ package muxtracer
 
 import (
 	"log"
-	"sync/atomic"
 	"time"
 )
 
@@ -32,11 +31,11 @@ func (m *Mutex) EnableTracerWithOpts(o Opts) {
 	if o.Id != "" {
 		m.id = []byte(o.Id)
 	}
-	atomic.StoreUint64(&m.threshold, uint64(o.Threshold.Nanoseconds()))
+	m.threshold.Store(uint64(o.Threshold.Nanoseconds()))
 }
 
 func (m *Mutex) DisableTracer() {
-	atomic.StoreUint64(&m.threshold, 0)
+	m.threshold.Store(0)
 }
 
 func (m *RWMutex) EnableTracer() {
@@ -47,11 +46,11 @@ func (m *RWMutex) EnableTracerWithOpts(o Opts) {
 	if o.Id != "" {
 		m.id = []byte(o.Id)
 	}
-	atomic.StoreUint64(&m.threshold, uint64(o.Threshold.Nanoseconds()))
+	m.threshold.Store(uint64(o.Threshold.Nanoseconds()))
 }
 
 func (m *RWMutex) DisableTracer() {
-	atomic.StoreUint64(&m.threshold, 0)
+	m.threshold.Store(0)
 }
 
 type Id []byte


### PR DESCRIPTION
The previous version of the code would normally fail when used on a 32-bit architecture with a message "panic: unaligned 64-bit atomic operation". It turns out that `atomic` requires loads and stores on 64-bit numbers that are 64-bit aligned, which doesn't happen by default on 32-bit architectures.

Fortunately, the `atomic.Uint64` type is guaranteed to always be 64-bit aligned. (See https://pkg.go.dev/sync/atomic#pkg-note-BUG). So we can instead just use these instead of plain uint64 values. This commit changes all the unit64 values that we atomically load or store into `atomic.Uint64`.

This code has been tested on a 32-bit ARMv6 processor (and works!)